### PR TITLE
Only get release notes from added files

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -42,6 +42,8 @@ for commit in event_data['commits']:
   print(INFO + "Examining files in commit " + str(commit['id']) + ENDC)
   c = repo.get_commit(sha=commit['id'])
   for f in c.files:
+    if f.status != "added":
+      continue
     print(INFO + "Found file " + f.filename + ENDC)
     if f.filename.startswith('.release-notes/'):
       if not f.filename.endswith('next-release.md'):


### PR DESCRIPTION
Prior to this commit, we would also potentially get release notes
from files that had been removed during a commit which is not
at all what we would want.

The same applies to files that were moved or changed. We do not
consider them as it is unknown to us why that would happen.

Our workflow is:

- New release notes file is added as part of PR
- On PR being merged `next-release.md` is updated from the newly added file

Closes #6