### PR TITLE
Pull latest changes before pushing

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -75,5 +75,8 @@ for rnf in release_notes_files:
 git.add('.release-notes/next-release.md')
 git.commit('-m', "Updating release notes for PR #" + str(pr_id)+ " [skip-ci]")
 
+print(INFO + "Pulling latest changes." + ENDC)
+git.pull()
+
 print(INFO + "Pushing updated release notes." + ENDC)
 git.push()


### PR DESCRIPTION
We ran into an error with a race condition between changelog-bot and this action in the action-testing repo.

This should hopefully help alleviate.