### PR TITLE
Lint entrypoint.py

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,13 +3,21 @@ name: PR
 on: pull_request
 
 jobs:
+  lint-entrypoint-py:
+    name: Lint entrypoint.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: pylint
+        run: make pylint
+
   validate-docker-image-builds:
     name: Validate Docker image builds
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --pull ."
+        run: make build
 
   verify-changelog:
     name: Verify CHANGELOG is valid

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --update \
   git \
   py3-pip
 
-RUN pip3 install gitpython PyGithub
+RUN pip3 install \
+  gitpython \
+  PyGithub \
+  pylint
 
 ENTRYPOINT ["/entrypoint.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TAG := docker.pkg.github.com/ponylang/release-notes-bot-action/release-notes-bot:latest
+
+all: build
+
+build:
+	docker build --pull -t ${TAG} .
+
+pylint: build
+	docker run --entrypoint pylint --rm ${TAG} /entrypoint.py
+
+.PHONY: build pylint

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,18 +1,25 @@
 #!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
 
-import git,json,os,sys
+import json
+import os
+import sys
+import git
 from github import Github
 
-changelog_labels = ['changelog - added', 'changelog - changed', 'changelog - fixed']
+CHANGELOG_LABELS = ['changelog - added',
+                    'changelog - changed',
+                    'changelog - fixed']
 
-ENDC   = '\033[0m'
-ERROR  = '\033[31m'
-INFO   = '\033[34m'
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
 NOTICE = '\033[33m'
 
-if not 'API_CREDENTIALS' in os.environ:
-  print(ERROR + "API_CREDENTIALS needs to be set in env. Exiting." + ENDC)
-  sys.exit(1)
+if 'API_CREDENTIALS' not in os.environ:
+    print(ERROR + "API_CREDENTIALS needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
 
 # login
 github = Github(os.environ['API_CREDENTIALS'])
@@ -31,8 +38,8 @@ print(INFO + "Query: " + query + ENDC)
 results = github.search_issues(query='is:merged', sha=sha, repo=repo_name)
 
 if results.totalCount == 0:
-  print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
-  sys.exit(0)
+    print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
+    sys.exit(0)
 
 pr_id = results[0].number
 print(INFO + "PR found " + str(pr_id) + ENDC)
@@ -41,24 +48,28 @@ print(INFO + "PR found " + str(pr_id) + ENDC)
 release_notes_files = []
 repo = github.get_repo(repo_name)
 for commit in event_data['commits']:
-  print(INFO + "Examining files in commit " + str(commit['id']) + ENDC)
-  c = repo.get_commit(sha=commit['id'])
-  for f in c.files:
-    if f.status != "added":
-      continue
-    print(INFO + "Found file " + f.filename + ENDC)
-    if f.filename.startswith('.release-notes/'):
-      if not f.filename.endswith('next-release.md'):
-        release_notes_files.append(f.filename)
+    print(INFO + "Examining files in commit " + str(commit['id']) + ENDC)
+    c = repo.get_commit(sha=commit['id'])
+    for f in c.files:
+        if f.status != "added":
+            continue
+        print(INFO + "Found file " + f.filename + ENDC)
+        if f.filename.startswith('.release-notes/'):
+            if not f.filename.endswith('next-release.md'):
+                release_notes_files.append(f.filename)
 
 # if no release notes files, exit
 if not release_notes_files:
-  print(NOTICE + "No release notes file found in commits. Exiting." + ENDC)
-  sys.exit(0)
+    print(NOTICE + "No release notes file found in commits. Exiting." + ENDC)
+    sys.exit(0)
 
 print(INFO + "Cloning repo." + ENDC)
 pull_request = repo.get_pull(pr_id)
-clone_from = "https://" + os.environ['GITHUB_ACTOR'] + ":" + os.environ['API_CREDENTIALS'] + "@github.com/" + repo_name
+clone_from = "https://" + os.environ['GITHUB_ACTOR'] \
+              + ":" \
+              + os.environ['API_CREDENTIALS'] \
+              + "@github.com/" \
+              + repo_name
 pr_base_branch = pull_request.base.ref
 clone_options = ["--branch=" + pr_base_branch]
 git = git.Repo.clone_from(clone_from, '.', multi_options=clone_options).git
@@ -70,44 +81,47 @@ git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
 # check to make sure that the PR had a changelog label
 # if it didn't delete the release notes file(s) and exit.
 found_changelog_label = False
-for l in pull_request.labels:
-  print(INFO + "PR had label: " + l.name + ENDC)
-  if l.name in changelog_labels:
-    found_changelog_label = True
-    break
+for prl in pull_request.labels:
+    print(INFO + "PR had label: " + prl.name + ENDC)
+    if prl.name in CHANGELOG_LABELS:
+        found_changelog_label = True
+        break
 
 if found_changelog_label:
-  print(NOTICE + "Processing release notes." + ENDC)
-  release_notes = ""
-  for rnf in release_notes_files:
-    release_notes += open(rnf, 'r').read().rstrip() + '\n\n'
-  next_release_notes = open('.release-notes/next-release.md', 'a+')
-  next_release_notes.write(release_notes)
-  next_release_notes.close()
+    print(NOTICE + "Processing release notes." + ENDC)
+    release_notes = ""
+    for rnf in release_notes_files:
+        release_notes += open(rnf, 'r').read().rstrip() + '\n\n'
+    next_release_notes = open('.release-notes/next-release.md', 'a+')
+    next_release_notes.write(release_notes)
+    next_release_notes.close()
 
-  print(INFO + "Adding git changes." + ENDC)
-  for rnf in release_notes_files:
-    git.rm(rnf)
-  git.add('.release-notes/next-release.md')
-  git.commit('-m', "Updates release notes for PR #" + str(pr_id))
+    print(INFO + "Adding git changes." + ENDC)
+    for rnf in release_notes_files:
+        git.rm(rnf)
+    git.add('.release-notes/next-release.md')
+    git.commit('-m', "Updates release notes for PR #" + str(pr_id))
 else:
-  print(NOTICE + "Found release notes but no changelog label." + ENDC)
-  for rnf in release_notes_files:
-    git.rm(rnf)
-  git.commit('-m', "Removes release notes from changelog labelless PR #"
-    + str(pr_id))
+    print(NOTICE + "Found release notes but no changelog label." + ENDC)
+    for rnf in release_notes_files:
+        git.rm(rnf)
+    git.commit('-m',
+               "Removes release notes from changelog labelless PR #"
+               + str(pr_id))
 
 print(INFO + "Pushing changes." + ENDC)
 push_failures = 0
-while(True):
-  try:
-    git.push()
-    break
-  except:
-    push_failures += 1
-    if (push_failures <= 5):
-      print(NOTICE + "Failed to push. Going to pull and try again." + ENDC)
-      git.pull()
-    else:
-      print(ERROR + "Failed to push again. Giving up." + ENDC)
-      raise
+while True:
+    try:
+        git.push()
+        break
+    except git.GitCommandError:
+        push_failures += 1
+        if push_failures <= 5:
+            print(NOTICE
+                  + "Failed to push. Going to pull and try again."
+                  + ENDC)
+            git.pull()
+        else:
+            print(ERROR + "Failed to push again. Giving up." + ENDC)
+            raise


### PR DESCRIPTION
Sets up linting of entrypoint.sh. I previously tried to do using
GitHub's superlinter, however, being able to use Python linters
with the required dependencies is a bit of a nightmare.

This update includes pylink in the same docker container that our
action normally runs in making it easy to build for both running
and for linting of the code.

Also included is a Makefile that currently allows for building
the container as well as linting it via two targets:

- build
- pylint

The Makefile is a first step towards being able to build fixed containers
on release and use those rather than rebuilding each time the action is
used for actions in various workflows. I'm planning on hosting those
released versions in GitHub packages, thus the stub "tag" in the Makefile
referencing the GitHub packages url. The name in the tag is currently unimportant
and can be ignored until such time as a push action is added to Makefile at
which point the tag name will become "real".

This commit also includes changes to entrypoint.py needed to get it to pass
the pylint linting.