### PR TITLE
Improve logging around multiple push attempts

### DIFF
--- a/.release-notes/improve-pull-messaging.md
+++ b/.release-notes/improve-pull-messaging.md
@@ -1,0 +1,5 @@
+## Improve logging around multiple push attempts
+
+Previously, if the bot failed to push its updates, it would create a log message for each pull that it attempted but only for the first push. This could be confusing to the user.
+
+Now each push and pull attempt will be logged.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -111,10 +111,10 @@ else:
                "Removes release notes from changelog labelless PR #"
                + str(pr_id))
 
-print(INFO + "Pushing changes." + ENDC)
 push_failures = 0
 while True:
     try:
+        print(INFO + "Pushing changes." + ENDC)
         git.push()
         break
     except GitCommandError:


### PR DESCRIPTION
Previously, if the bot failed to push its updates, it would create a
log message for each pull that it attempted but only for the first
push. This could be confusing to the user.

Now each push and pull attempt will be logged.