### PR TITLE
Update to work with newer versions of git

### DIFF
--- a/.release-notes/cranky-git.md
+++ b/.release-notes/cranky-git.md
@@ -1,0 +1,5 @@
+## Update to work with newer versions of git
+
+Newer versions of git have added a check to see if the user running a command is the same as the user who owns the repository. If they don't match, the command fails. Adding the repository directory to a "safe list" addresses the issue.
+
+We've updated accordingly.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -79,6 +79,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 # check to make sure that the PR had a changelog label
 # if it didn't delete the release notes file(s) and exit.


### PR DESCRIPTION
Newer versions of git have added a check to see if the user running a command
is the same as the user who owns the repository. If they don't match, the
command fails. Adding the repository directory to a "safe list" addresses the
issue.