### PR TITLE
Add sleep and retry when secondary rate limit impacts on PR search

### DIFF
--- a/.release-notes/38.md
+++ b/.release-notes/38.md
@@ -1,0 +1,9 @@
+## Handle GitHub secondary rate limit failure
+
+The release-notes-bot-action makes extensive use of the GitHub API. As such, it can trigger rate limits that cause a failure. We've found that it is rather easy when using the bot across a number of repositories to hit a "secondary rate limit failure". Basically that is "you are doing too many API calls at once".
+
+The error is transient. If someone was to notice, they could restart the failed release-notes-bot run and it would work. However, that requires someone to notice.
+
+With this release, we've added a retry for the one time we know that the limit can be triggered. If the rate limit is triggered, the bot will wait for 30 seconds before trying again. If it encounters 5 failures, it will give up and quit.
+
+It is possible that we'll need to add similar returns around other GitHub API calls. If we do, additional updates will be made.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -2,12 +2,14 @@
 # pylint: disable=C0103
 # pylint: disable=C0114
 
+import time
 import json
 import os
 import sys
 import git
 from git.exc import GitCommandError
 from github import Github
+from github.GithubException import RateLimitExceededException
 
 CHANGELOG_LABELS = ['changelog - added',
                     'changelog - changed',
@@ -37,14 +39,31 @@ repo_name = event_data['repository']['full_name']
 print(INFO + "Finding PR associated with " + sha + " in " + repo_name + ENDC)
 query = "q=is:merged+sha:" + sha + "+repo:" + repo_name
 print(INFO + "Query: " + query + ENDC)
-results = github.search_issues(query='is:merged', sha=sha, repo=repo_name)
+pr_id = 0
+search_failures = 0
+while True:
+    try:
+        results = github.search_issues(query='is:merged', sha=sha,
+                                       repo=repo_name)
 
-if results.totalCount == 0:
-    print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
-    sys.exit(0)
+        if results.totalCount == 0:
+            print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
+            sys.exit(0)
 
-pr_id = results[0].number
-print(INFO + "PR found " + str(pr_id) + ENDC)
+        pr_id = results[0].number
+        print(INFO + "PR found " + str(pr_id) + ENDC)
+        break
+    except RateLimitExceededException:
+        search_failures += 1
+        if search_failures <= 5:
+            print(NOTICE
+                  + "Search failed due to rate limit exceeded. "
+                  + "Sleeping and trying again."
+                  + ENDC)
+            time.sleep(30)
+        else:
+            print(ERROR + "Search failed again. Giving up." + ENDC)
+            raise
 
 # find associated release notes file
 release_notes_files = []


### PR DESCRIPTION
We hit this error semi-regularly. GitHub's secondary rate limiting is easy to trigger. It often will happen if multiple requests to the API are made at the same time from different jobs resulting in a failure. The failure is easy to fix by rerunning the job, but a user has to notice.

There might be other places that we can hit a similar issue, but this commit addresses the known location.

Fixes #37