### PR TITLE
Fix bug when release notes files appeared in more than one commit

### DIFF
--- a/.release-notes/set-not-list.md
+++ b/.release-notes/set-not-list.md
@@ -1,0 +1,7 @@
+## Fix a failure when release notes appear in more than one commit
+
+If more than 1 commit was associated with a PR and more than one commit included the same release notes file, this actual would previously fail.
+
+We've updated to make sure it only processes each file once as compared to before when it would attempt to process each release notes file for every occurrence across all commits.
+
+You can also call this fix: "use set, not list".

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -66,7 +66,7 @@ while True:
             raise
 
 # find associated release notes file
-release_notes_files = []
+release_notes_files = set()
 repo = github.get_repo(repo_name)
 for commit in event_data['commits']:
     print(INFO + "Examining files in commit " + str(commit['id']) + ENDC)
@@ -77,7 +77,7 @@ for commit in event_data['commits']:
         print(INFO + "Found file " + f.filename + ENDC)
         if f.filename.startswith('.release-notes/'):
             if not f.filename.endswith('next-release.md'):
-                release_notes_files.append(f.filename)
+                release_notes_files.add(f.filename)
 
 # if no release notes files, exit
 if not release_notes_files:


### PR DESCRIPTION
We were storing found release notes files in a list rather than a set. This could result in trying to process a file more than once which would end up as a failure when it tried to run `git rm` an additional time.