### PR TITLE
Switch container image pruning to snok/container-retention-policy

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -8,7 +8,7 @@ on:
 concurrency: announce-a-release
 
 permissions:
-  packages: read
+  packages: write
   contents: write
 
 jobs:
@@ -75,10 +75,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prune
-        # v4.1.1
-        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        # v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
         with:
-          package-name: 'release-notes-bot-action'
-          package-type: 'container'
-          min-versions-to-keep: 1
-          delete-only-untagged-versions: 'true'
+          account: ponylang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: release-notes-bot-action
+          tag-selection: untagged
+          cut-off: 1d


### PR DESCRIPTION
Migrate from actions/delete-package-versions to snok/container-retention-policy for consistency with the multiplatform image pruning already in use in shared-docker and ponyc.

Also fixes the packages permission from read to write, which is required for deleting package versions.