### PR TITLE
Fix GitHub API race condition when finding PR for a commit

### DIFF
--- a/.release-notes/fix-github-api-race.md
+++ b/.release-notes/fix-github-api-race.md
@@ -1,0 +1,3 @@
+## Fix GitHub API race condition when finding PR for a commit
+
+The bot could fail to find a PR associated with a commit if the GitHub search API hadn't finished indexing the merge yet. The bot now retries up to 5 times with a 10-second delay before concluding there's no associated PR.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -41,6 +41,7 @@ print(INFO + "Finding PR associated with " + sha + " in " + repo_name + ENDC)
 query = "q=is:merged+sha:" + sha + "+repo:" + repo_name
 print(INFO + "Query: " + query + ENDC)
 pr_id = 0
+no_pr_failures = 0
 search_failures = 0
 while True:
     try:
@@ -56,8 +57,19 @@ while True:
             print(INFO + "PR found " + str(pr_id) + ENDC)
             break
         except IndexError:
-            print(NOTICE + "No merged PR associated with " + sha + ". Exiting." + ENDC)
-            sys.exit(0)
+            no_pr_failures += 1
+            if no_pr_failures <= 5:
+                print(NOTICE
+                      + "No merged PR associated with " + sha + " yet. "
+                      + "Sleeping and trying again."
+                      + ENDC)
+                time.sleep(10)
+            else:
+                print(NOTICE
+                      + "No merged PR associated with " + sha
+                      + ". Exiting."
+                      + ENDC)
+                sys.exit(0)
     except RateLimitExceededException:
         search_failures += 1
         if search_failures <= 5:


### PR DESCRIPTION
The GitHub search API has an eventual consistency issue where immediately after a merge, searching for the PR by commit SHA returns no results. A few seconds later, it works fine. The bot was exiting cleanly on empty results, silently skipping release notes processing.

Now retries up to 5 times with a 10-second delay before concluding there's no associated PR.